### PR TITLE
Ensure that all selected elements have redacted font applied

### DIFF
--- a/js/redacted-regular-selected.js
+++ b/js/redacted-regular-selected.js
@@ -13,5 +13,15 @@
   var span = document.createElement("span");
   span.style.fontFamily = "Redacted Regular";
   span.appendChild(selectedText);
+  exploreChildren(span);
   selection.insertNode(span);
+  function exploreChildren(element) {
+    element.style.fontFamily = "Redacted Regular";
+    var elementChildren = element.children;
+    if(elementChildren !== undefined && elementChildren.length > 0) {
+      for(var i = 0; i < elementChildren.length; i++) {
+        exploreChildren(elementChildren[i]);
+      }
+    }
+  }
 })();

--- a/js/redacted-script-bold-selected.js
+++ b/js/redacted-script-bold-selected.js
@@ -13,5 +13,15 @@
   var span = document.createElement("span");
   span.style.fontFamily = "Redacted Script Bold";
   span.appendChild(selectedText);
+  exploreChildren(span);
   selection.insertNode(span);
+  function exploreChildren(element) {
+    element.style.fontFamily = "Redacted Script Bold";
+    var elementChildren = element.children;
+    if(elementChildren !== undefined && elementChildren.length > 0) {
+      for(var i = 0; i < elementChildren.length; i++) {
+        exploreChildren(elementChildren[i]);
+      }
+    }
+  }
 })();

--- a/js/redacted-script-light-selected.js
+++ b/js/redacted-script-light-selected.js
@@ -13,5 +13,15 @@
   var span = document.createElement("span");
   span.style.fontFamily = "Redacted Script Light";
   span.appendChild(selectedText);
+  exploreChildren(span);
   selection.insertNode(span);
+  function exploreChildren(element) {
+    element.style.fontFamily = "Redacted Script Light";
+    var elementChildren = element.children;
+    if(elementChildren !== undefined && elementChildren.length > 0) {
+      for(var i = 0; i < elementChildren.length; i++) {
+        exploreChildren(elementChildren[i]);
+      }
+    }
+  }
 })();

--- a/js/redacted-script-regular-selected.js
+++ b/js/redacted-script-regular-selected.js
@@ -13,5 +13,15 @@
   var span = document.createElement("span");
   span.style.fontFamily = "Redacted Script Regular";
   span.appendChild(selectedText);
+  exploreChildren(span);
   selection.insertNode(span);
+  function exploreChildren(element) {
+    element.style.fontFamily = "Redacted Script Regular";
+    var elementChildren = element.children;
+    if(elementChildren !== undefined && elementChildren.length > 0) {
+      for(var i = 0; i < elementChildren.length; i++) {
+        exploreChildren(elementChildren[i]);
+      }
+    }
+  }
 })();


### PR DESCRIPTION
I tried using the selected scripts, and for child elements that have other fonts, it wouldn't apply.  I created this small recursive function to loop through all the child elements and apply the redacted font to each element.